### PR TITLE
Fix urllib3 Vulnerability Warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,5 +40,5 @@ pytz==2017.3              # via zeep
 requests-toolbelt==0.8.0  # via zeep
 requests==2.18.4          # via requests-toolbelt, zeep
 six==1.11.0               # via isodate, mock, pip-tools, pytest, zeep
-urllib3==1.22             # via requests
+urllib3==1.24.2           # via requests
 zeep==2.4.0


### PR DESCRIPTION
Updates to version 1.24.2, as GitHub recommends.